### PR TITLE
Included a note within the Local Internship on GRT discontinuation

### DIFF
--- a/_internships/Local Internships.md
+++ b/_internships/Local Internships.md
@@ -21,8 +21,13 @@ a minimum monthly internship stipend of:</p>
 <li>
 <p><strong>S$1,000 for degree students</strong>
 </p>
+<p></p>
 </li>
 </ul>
+<p>Note: Applications for the GRT local internships funding (i.e., internship
+stipend support) will close on 31 January 2026.</p>
+<p>All supported internships must start no later than 31 March 2026 and end
+no later than 30 March 2027.”</p>
 <h4>Deliverables</h4>
 <p>A student who interns in Singapore with a Singapore Enterprise applying
 for GRT Programme funding is expected to complete mandatory internship


### PR DESCRIPTION
Hi Stacy, I have included the below note under Internships >> Local internships to notify students regarding the discontinuation of GRT local internship funding. Please help to publish on 15 October 2025 (AM). Thank you.

"Note: Applications for the GRT local internships funding (i.e., internship stipend support) will close on 31 January 2026. All supported internships must start no later than 31 March 2026 and end no later than 30 March 2027.” 